### PR TITLE
More detailed SubmitTransactionResponse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "stellar_sdk"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stellar_sdk"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = ["Matin Kaboli <matinkaboli@aol.com>"]
 description = "stellar_sdk is a library for working with the Stellar Horizon server"

--- a/src/endpoints/horizon.rs
+++ b/src/endpoints/horizon.rs
@@ -94,6 +94,7 @@ pub struct Flags {
     pub auth_required: bool,
     pub auth_revocable: bool,
     pub auth_immutable: bool,
+    #[serde(default)] // Backwards compatibility with protocol version 15 for example where this auth_clawback_enabled field not existing
     pub auth_clawback_enabled: bool,
 }
 

--- a/src/endpoints/server.rs
+++ b/src/endpoints/server.rs
@@ -268,7 +268,7 @@ impl Server {
         transaction: TransactionSBase,
     ) -> Result<SubmitTransactionResponse, anyhow::Error> {
         let tx = transaction.into_envelope().xdr_base64()?;
-        let url = format!("{}/transactions/", self.server_url);
+        let url = format!("{}/transactions", self.server_url);
 
         let mut query = HashMap::new();
         query.insert("tx".to_string(), tx.to_string());

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -12,6 +12,7 @@ pub struct Keypair {
     secret_seed: Option<Vec<u8>>,
 }
 
+#[allow(dead_code)]
 impl Keypair {
     fn new_from_secret_key(secret_seed: Vec<u8>) -> Result<Self, anyhow::Error> {
         if secret_seed.len() != 32 {

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -1,10 +1,11 @@
 use anyhow::bail;
 use nacl::sign::{generate_keypair, signature, verify};
 use str_key::StrKey;
+use stellar_base::crypto::{SecretKey, KeyPair};
 
 use crate::str_key;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Keypair {
     public_key: Vec<u8>,
     secret_key: Option<Vec<u8>>,
@@ -116,6 +117,25 @@ impl Keypair {
     }
 }
 
+// Easy conversion between stellar_sdk and stellar_base keypairs and vica versa
+impl From<Keypair> for KeyPair {
+    fn from(sdk_keypair: Keypair) -> Self {
+        let mut sdk_keypair_inner = sdk_keypair;
+        let secret_key: String = sdk_keypair_inner.secret_key().expect("Failed to get the secret key from the stellar_sdk::Keypair");
+        let stellar_base_keypair = KeyPair::from_secret_seed(&secret_key).expect("Failed to convert to generate stellar_base::KeyPair from the secret seed");
+        stellar_base_keypair
+    }
+}
+
+impl From<KeyPair> for Keypair {
+    fn from(base_keypair: KeyPair) -> Self {
+        let secret_key_struct: &SecretKey = base_keypair.secret_key();
+        let secret_key: String = secret_key_struct.secret_seed().into();
+        let stellar_sdk_keypair = Keypair::from_secret_key(&secret_key).expect("Failed to convert to generate stellar_sdk::Keypair from the secret seed");
+        stellar_sdk_keypair
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -198,5 +218,14 @@ mod tests {
 
         assert_ne!(keypair_1.raw_secret_key(), keypair_2.raw_secret_key());
         assert_ne!(keypair_2.raw_secret_key(), keypair_3.raw_secret_key());
+    }
+
+    #[test]
+    fn test_keypair_conversion() {
+        let keypair_sdk = Keypair::random().unwrap();
+        let keypair_base: KeyPair = keypair_sdk.clone().into();
+        let keypair_sdk2: Keypair = keypair_base.into();
+    
+        assert_eq!(keypair_sdk, keypair_sdk2);
     }
 }

--- a/src/types/submit_transaction_response.rs
+++ b/src/types/submit_transaction_response.rs
@@ -1,12 +1,91 @@
 use serde::{Deserialize, Serialize};
+// https://developers.stellar.org/api/horizon/resources/submit-a-transaction
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SubmitTransactionResponse {
-    hash: String,
-    ledger: u64,
-    successful: bool,
-    envelope_xdr: String,
-    result_xdr: String,
-    result_meta_xdr: String,
-    paging_token: String,
+    pub memo: Option<String>,
+    pub memo_bytes: Option<String>,
+    #[serde(rename = "_links")]
+    pub links: Links,
+    pub id: String,
+    pub paging_token: String,
+    pub successful: bool,
+    pub hash: String,
+    pub ledger: i32,
+    pub created_at: String,
+    pub source_account: String,
+    pub account_muxed: Option<String>,
+    pub account_muxed_id: Option<String>,
+    pub source_account_sequence: String,
+    pub fee_account: String,
+    pub fee_account_muxed: Option<String>,
+    pub fee_account_muxed_id: Option<String>,
+    pub fee_charged: String,
+    pub max_fee: String,
+    pub operation_count: i32,
+    pub envelope_xdr: String,
+    pub result_xdr: String,
+    pub result_meta_xdr: String,
+    pub fee_meta_xdr: Option<String>,
+    pub memo_type: String,
+    pub signatures: Vec<String>,
+    pub valid_after: Option<String>,
+    pub valid_before: Option<String>,
+    pub preconditions: Option<Preconditions>,
+    pub fee_bump_transaction: Option<FeeBumpTransaction>,
+    pub inner_transaction: Option<InnerTransaction>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Links {
+    #[serde(rename = "self")]
+    pub links_self: Link,
+    pub account: Link,
+    pub ledger: Link,
+    pub operations: Link,
+    pub effects: Link,
+    pub precedes: Link,
+    pub succeeds: Link,
+    pub transaction: Link,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Link {
+    pub href: String,
+    pub templated: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Preconditions {
+    pub timebounds: Option<TimeboundsString>,
+    pub ledgerbounds: Option<Ledgerbounds>,
+    pub min_account_sequence: Option<String>,
+    pub min_account_sequence_age: Option<String>,
+    pub min_account_sequence_ledger_gap: Option<i32>,
+    pub extra_signers: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ledgerbounds {
+    pub min_ledger: Option<String>,
+    pub max_ledger: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TimeboundsString {
+    pub min_time: Option<String>,
+    pub max_time: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FeeBumpTransaction {
+    pub hash: Option<String>,
+    pub signatures: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InnerTransaction {
+    pub hash: Option<String>,
+    pub signatures: Option<Vec<String>>,
+    pub max_fee: Option<String>,
 }


### PR DESCRIPTION
SubmitTransactionResponse made more detailed based on Horizon API.

Struct conversion between stellar_base and stellar_sdk packages going to be useful when someone trying to use both crates together.

I've also bumped up the version number.
Can I ask for a `cargo publish` ? I would like to use this version in my library. And cargo not letting me to publish if I'm linking in from github. Thanks for the to do list now I can see what should have be do next :)

Update:
I tried to do almost all of the todo list functions but with every route I tries I hit a wall. I guess without changing the types the functions can't be done. I hope we can decide how to progress further, will re export or copy stellar_base types (unfortunatelly rarely maintained crate), or what would be the most optimal way.