### PR TITLE
Improve error handling

### DIFF
--- a/src/api_call.rs
+++ b/src/api_call.rs
@@ -1,4 +1,3 @@
-use anyhow::anyhow;
 use serde::de::DeserializeOwned;
 use std::collections::HashMap;
 use ureq::{self, Error as UreqError};
@@ -38,7 +37,7 @@ pub fn api_call<T: DeserializeOwned>(
                 let res_str = res.into_string()?;
                 let parsed: HorizonError = serde_json::from_str(&res_str)?;
 
-                Err(anyhow!("{:?}", parsed))
+                Err(parsed.into())
             }
             other => Err(other.into()),
         },

--- a/src/types/horizon_error.rs
+++ b/src/types/horizon_error.rs
@@ -8,7 +8,7 @@ pub struct HorizonError {
     pub r#type: String,
     pub title: String,
     pub status: i16,
-    pub detail: String,
+    pub detail: Option<String>,
     pub extras: Option<ExtraHorizonError>,
 }
 


### PR DESCRIPTION
1. If a Stellar node is behind a gateway, and the gateway generates an error, e.g., 429 - Too many requests, the error might not contain the "detail" field.
2. Without it, it is impossible to differentiate between Horizon errors via `anyhow::downcast`.